### PR TITLE
fix(sec): upgrade numpy to 1.22.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi==2019.11.28
 dominate==2.4.0
 grpcio==1.16.1
 Markdown==3.1.1
-numpy==1.18.1
+numpy==1.22.2
 nvidia-ml-py3==7.352.0
 olefile==0.46
 opencv-python==4.2.0.32


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in numpy 1.18.1
- [CVE-2021-33430](https://www.oscs1024.com/hd/CVE-2021-33430)


### What did I do？
Upgrade numpy from 1.18.1 to 1.22.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS